### PR TITLE
1.1.2

### DIFF
--- a/Proactive Remediation/Remediate.ps1
+++ b/Proactive Remediation/Remediate.ps1
@@ -278,7 +278,7 @@ Process {
 
     # Control whether client-side events should be sent to Log Analytics workspace
     # Set to $true to enable this feature
-    $SendClientEvent = $true
+    $SendClientEvent = $false
 
     # Define event log variables
     $EventLogName = "CloudLAPS-Client"

--- a/Proactive Remediation/Remediate.ps1
+++ b/Proactive Remediation/Remediate.ps1
@@ -14,7 +14,7 @@
     Author:      Nickolaj Andersen
     Contact:     @NickolajA
     Created:     2020-09-14
-    Updated:     2022-01-27
+    Updated:     2022-05-13
 
     Version history:
     1.0.0 - (2020-09-14) Script created
@@ -22,6 +22,7 @@
     1.0.2 - (2022-01-01) Updated virtual machine array with 'Google Compute Engine'
     1.1.0 - (2022-01-08) Added support for new SendClientEvent function to send client events related to passwor rotation
     1.1.1 - (2022-01-27) Added validation check to test if device is either AAD joined or Hybrid Azure AD joined
+    1.1.2 - (2022-05-13) Added support for "User must change password at next logon" checkbox. In that case, the account will be re-created. 
 #>
 Process {
     # Functions

--- a/Proactive Remediation/Remediate.ps1
+++ b/Proactive Remediation/Remediate.ps1
@@ -384,7 +384,7 @@ Process {
                             if (!($PasswordLastSet)) {
                                 Write-EventLog -LogName $EventLogName -Source $EventLogSource -EntryType Information -EventId 32 -Message "CloudLAPS: Local administrator account exists but is configured with 'User must change password at next logon', attempting to re-create account '$($LocalAdministratorName)'"
                                 try {
-                                    Write-EventLog -LogName $EventLogName -Source $EventLogSource -EntryType Information -EventId 34 -Message "CloudLAPS: Local administrator deleted."
+                                    Write-EventLog -LogName $EventLogName -Source $EventLogSource -EntryType Information -EventId 34 -Message "CloudLAPS: Local administrator account deleted."
                                     Remove-LocalUser -Name $LocalAdministratorName -Force
                                     Write-EventLog -LogName $EventLogName -Source $EventLogSource -EntryType Information -EventId 20 -Message "CloudLAPS: Local administrator account does not exist, attempt to create it"
                                     New-LocalUser -Name $LocalAdministratorName -Password $SecurePassword -PasswordNeverExpires -AccountNeverExpires -UserMayNotChangePassword -ErrorAction Stop
@@ -396,7 +396,6 @@ Process {
                                             Add-LocalGroupMember -SID $Group -Member $LocalAdministratorName -ErrorAction Stop
                                         }
 
-                                        
                                         # Handle output for extended details in MEM portal
                                         $ExtendedOutput = "AdminAccountCreated"
                                     }


### PR DESCRIPTION
When an account receives new password policies (via devicelock) via Intune, the account will be marked as "User must change password at next logon". After that, this setting cannot programatically via code be removed, and the only way a user or admin can reset that flag is by interactively login in with that account. (More can be found [here](https://smsagent.blog/2021/04/27/a-case-of-the-unexplained-intune-password-policy-and-forced-local-account-password-changes/) about this issue).

To fix that, i've added code to the remediate script which checks if the flag (PasswordLastSet) is selected on the account, and then it removes and re-adds the account with the same name.



