### PR TITLE
Add support for localized Administrator name

### DIFF
--- a/Proactive Remediation/Remediate.ps1
+++ b/Proactive Remediation/Remediate.ps1
@@ -298,7 +298,7 @@ Process {
 
     if (-not($LocalAdministratorName)) {
         $LocalAdministratorName = (Get-LocalUser | Where-Object {$_.SID -like "*-500"}).Name
-        Enable-LocalUser -Name $LocalAdministratorName
+        Enable-LocalUser -Name $LocalAdministratorName -ErrorAction SilentlyContinue
     }
 
     # Construct the required URI for the Azure Function URL

--- a/Proactive Remediation/Remediate.ps1
+++ b/Proactive Remediation/Remediate.ps1
@@ -14,7 +14,7 @@
     Author:      Nickolaj Andersen
     Contact:     @NickolajA
     Created:     2020-09-14
-    Updated:     2022-10-16
+    Updated:     2022-12-28
 
     Version history:
     1.0.0 - (2020-09-14) Script created.
@@ -25,6 +25,7 @@
     1.1.2 - (2022-09-15) Support for detecting the device registration certificate based on deviceId instead of thumbprint data in JoinInfo key.
     1.2.0 - (2022-10-16) Added support to enforce password rotation of an existing device in CloudLAPS, after it has been re-provisioned.
                          Also extended the main try and catch with additional HTTP response codes for more detailed error messages.
+    1.2.1 - (2022-12-28) Added support for localized Administrator name (Administrateur, Administrador, etc.) by using default administrator's SID (*-500).
 #>
 Process {
     # Functions
@@ -294,6 +295,11 @@ Process {
 
     # Define the local administrator user name
     $LocalAdministratorName = "<Enter the name of the local administrator account>"
+	    
+	if (-not($LocalAdministratorName)) {
+        $LocalAdministratorName = (Get-LocalUser | Where-Object {$_.SID -like "*-500"}).Name
+        Enable-LocalUser -Name $LocalAdministratorName
+    }
 
     # Construct the required URI for the Azure Function URL
     $SetSecretURI = "<Enter Azure Functions URI for SetSecret function>"

--- a/Proactive Remediation/Remediate.ps1
+++ b/Proactive Remediation/Remediate.ps1
@@ -295,8 +295,8 @@ Process {
 
     # Define the local administrator user name
     $LocalAdministratorName = "<Enter the name of the local administrator account>"
-	    
-	if (-not($LocalAdministratorName)) {
+
+    if (-not($LocalAdministratorName)) {
         $LocalAdministratorName = (Get-LocalUser | Where-Object {$_.SID -like "*-500"}).Name
         Enable-LocalUser -Name $LocalAdministratorName
     }

--- a/Proactive Remediation/Remediate.ps1
+++ b/Proactive Remediation/Remediate.ps1
@@ -25,7 +25,7 @@
     1.1.2 - (2022-09-15) Support for detecting the device registration certificate based on deviceId instead of thumbprint data in JoinInfo key.
     1.2.0 - (2022-10-16) Added support to enforce password rotation of an existing device in CloudLAPS, after it has been re-provisioned.
                          Also extended the main try and catch with additional HTTP response codes for more detailed error messages.
-    1.2.1 - (2022-12-28) Added support for localized Administrator name (Administrateur, Administrador, etc.) by using default administrator's SID (*-500).
+    1.2.1 - (2022-12-28) Added support for localized Administrator name (Administrateur, Administrador, etc.) by using default administrator (SID *-500).
 #>
 Process {
     # Functions
@@ -293,7 +293,7 @@ Process {
         }
     }
 
-    # Define the local administrator user name
+    # Define the local administrator user name. Leave empty to retrieve default administrator (SID *-500).
     $LocalAdministratorName = "<Enter the name of the local administrator account>"
 
     if (-not($LocalAdministratorName)) {


### PR DESCRIPTION
Added support for localized Administrator name (_Administrateur, Administrador, etc._) in **Remediate.ps1** when different "base" OS language versions are in use.
When `$LocalAdministratorName` variable is empty, it retrieves the name of default local administrator (SID *-500). 

Fix #50 